### PR TITLE
cubie-a7*: dts: rename soundcard-mach,name

### DIFF
--- a/configs/cubie_a7a/linux-5.15/board.dts
+++ b/configs/cubie_a7a/linux-5.15/board.dts
@@ -2057,6 +2057,7 @@
 	soundcard-mach,bitclock-master	= <&i2s3_cpu>;
 	/* soundcard-mach,frame-inversion; */
 	/* soundcard-mach,bitclock-inversion; */
+	soundcard-mach,name = "allwinner-hdmi";
 	soundcard-mach,slot-num		= <2>;
 	soundcard-mach,slot-width	= <32>;
 	status		= "okay";

--- a/configs/cubie_a7a/linux-5.15/board.dts
+++ b/configs/cubie_a7a/linux-5.15/board.dts
@@ -1912,6 +1912,7 @@
     soundcard-mach,bitclock-master    = <&i2s0_cpu>;
     /* soundcard-mach,frame-inversion; */
     /* soundcard-mach,bitclock-inversion; */
+	soundcard-mach,name = "allwinner-ac101";
     soundcard-mach,slot-num        = <4>;
     soundcard-mach,slot-width    = <16>;
     soundcard-mach,jack-support    = <4>;

--- a/configs/cubie_a7z/linux-5.15/board.dts
+++ b/configs/cubie_a7z/linux-5.15/board.dts
@@ -1869,6 +1869,7 @@
 	soundcard-mach,bitclock-master	= <&i2s3_cpu>;
 	/* soundcard-mach,frame-inversion; */
 	/* soundcard-mach,bitclock-inversion; */
+	soundcard-mach,name = "allwinner-hdmi";
 	soundcard-mach,slot-num		= <2>;
 	soundcard-mach,slot-width	= <32>;
 	status		= "okay";


### PR DESCRIPTION
To avoid confusion with other devices when matching ALSA UCM configurations Link: https://github.com/radxa-pkg/radxa-alsa-config/pull/13