### PR TITLE
cubie-a5e: dts: set sdc0 1.8V IO power supply to reg_cldo1

### DIFF
--- a/configs/cubie_a5e/linux-5.15/board.dts
+++ b/configs/cubie_a5e/linux-5.15/board.dts
@@ -1242,8 +1242,8 @@
 	vmmc-supply = <&reg_cldo3>;
 	vqmmc33sw-supply = <&reg_cldo3>;
 	vdmmc33sw-supply = <&reg_cldo3>;
-	vqmmc18sw-supply = <&reg_cldo3>;
-	vdmmc18sw-supply = <&reg_cldo3>;
+	vqmmc18sw-supply = <&reg_cldo1>;
+	vdmmc18sw-supply = <&reg_cldo1>;
 	status = "okay";
 };
 


### PR DESCRIPTION
The correct 1.8V IO power supply of sdc0 is reg_cldo1.

fixes: https://applink.feishu.cn/client/message/link/open?token=Amg1LdbywUACaK7Zm9eGwBw%3D