### PR TITLE
cubie-a7z: dts: set usbc2 power-role to source

### DIFF
--- a/configs/cubie_a7z/linux-5.15/board.dts
+++ b/configs/cubie_a7z/linux-5.15/board.dts
@@ -1669,24 +1669,12 @@
 			compatible = "usb-c-connector";
 			label = "USB-C";
 			data-role = "dual";
-			power-role = "dual";
-			try-power-role = "sink";
+			power-role = "source";
 			op-sink-microwatt = <1000000>;
 			typec-power-opmode = "default";
-			//pd-disable;
 			slow-charger-loop;
-			sink-pdos = < PDO_FIXED(5000, 500, (0x1<<29)|(0x1<<25))
-						 PDO_VAR(5000, 5000, 2000)
-						/* PDO_VAR(9000, 9000, 2000)
-						 PDO_VAR(12000, 12000, 3000)
-						 PDO_VAR(15000, 15000, 3000)
-						 PDO_VAR(20000, 20000, 2250)*/
-						>;
 			source-pdos = < PDO_FIXED(5000, 500, (0x1<<29)|(0x1<<25))
 							PDO_VAR(5000, 5000, 1200) >;
-			/* fixme */
-			sink-vdos = <0xd1002e99 0x00 0x03110000>;
-			sink-vdos-v1 = <0xd1002e99 0x00 0x03110000>;
 
 			altmodes {
 				#address-cells = <1>;


### PR DESCRIPTION
This interface does not support power input.
And helps improve compatibility with screens using Type-C data cables.

fixes: https://vamrs.feishu.cn/sheets/EYKrsU23rh7vSLtiCWxc2Gq1nNh?sheet=RrHW8Z&rangeId=RrHW8Z_ebtVI5gWcd&rangeVer=1