### PR TITLE
cubie-a7*: dts: add "allwinner,sun60i-a733" to /compatible

### DIFF
--- a/configs/cubie_a7a/linux-5.15/board.dts
+++ b/configs/cubie_a7a/linux-5.15/board.dts
@@ -6,7 +6,7 @@
 #define TYPEC_DP 1
 /{
 	board = "A733", "A733-CUBIE-A7A-AXP318";
-	compatible = "radxa,cubie-a7a", "arm,sun60iw2p1";
+	compatible = "radxa,cubie-a7a", "arm,sun60iw2p1", "allwinner,sun60i-a733";
 	aliases {
 		arisc-config = &arisc_config;
 		pmu0 = &pmu0;

--- a/configs/cubie_a7s/linux-5.15/board.dts
+++ b/configs/cubie_a7s/linux-5.15/board.dts
@@ -6,7 +6,7 @@
 #define TYPEC_DP 1
 /{
 	board = "A733", "A733-CUBIE-A7S-AXP318";
-	compatible = "radxa,cubie-a7s", "arm,sun60iw2p1";
+	compatible = "radxa,cubie-a7s", "arm,sun60iw2p1", "allwinner,sun60i-a733";
 	aliases {
 		arisc-config = &arisc_config;
 		pmu0 = &pmu0;

--- a/configs/cubie_a7z/linux-5.15/board.dts
+++ b/configs/cubie_a7z/linux-5.15/board.dts
@@ -6,7 +6,7 @@
 #define TYPEC_DP 1
 /{
 	board = "A733", "A733-CUBIE-A7Z-AXP318";
-	compatible = "radxa,cubie-a7z", "arm,sun60iw2p1";
+	compatible = "radxa,cubie-a7z", "arm,sun60iw2p1", "allwinner,sun60i-a733";
 	aliases {
 		arisc-config = &arisc_config;
 		pmu0 = &pmu0;


### PR DESCRIPTION
Compatible with rsetup function `get_soc_vendor()`: https://github.com/radxa-pkg/rsetup/blob/f511568892c452efbc868d7275220186acec2b84/src/usr/lib/rsetup/mod/hwid.sh#L3

Make sure to find the correct overlay directory
when installing kernel and rebuilding overlay:
https://github.com/radxa-pkg/rsetup/blob/f511568892c452efbc868d7275220186acec2b84/src/usr/lib/rsetup/tui/overlay/overlay.sh#L226

fixes: https://applink.feishu.cn/client/message/link/open?token=Amg1LdbywUACaNE35JgFgAI%3D