### PR TITLE
cubie-a5e: dts: add "allwinner,sun55i-a527" to /compatible

### DIFF
--- a/configs/cubie_a5e/linux-5.15/board.dts
+++ b/configs/cubie_a5e/linux-5.15/board.dts
@@ -9,7 +9,7 @@
 
 /{
 	board = "A527", "A527-CUBIE-A5-AXP717C";
-	compatible = "radxa,cubie-a5e", "arm,sun55iw3p1";
+	compatible = "radxa,cubie-a5e", "arm,sun55iw3p1", "allwinner,sun55i-a527";
 	aliases {
 		pmu0 = &pmu0;
 		axp1530 = &axp1530;


### PR DESCRIPTION
Compatible with rsetup function `get_soc_vendor()`: https://github.com/radxa-pkg/rsetup/blob/f511568892c452efbc868d7275220186acec2b84/src/usr/lib/rsetup/mod/hwid.sh#L3

Make sure to find the correct overlay directory
when installing kernel and rebuilding overlay:
https://github.com/radxa-pkg/rsetup/blob/f511568892c452efbc868d7275220186acec2b84/src/usr/lib/rsetup/tui/overlay/overlay.sh#L226

fixes: https://applink.feishu.cn/client/message/link/open?token=Amg1LdbywUACaNE35JgFgAI%3D