### PR TITLE
arm64: dts: cubie-a7s: populate uart0 pinctrl (PB9/PB10)

### DIFF
--- a/configs/cubie_a7s/linux-6.6/board.dts
+++ b/configs/cubie_a7s/linux-6.6/board.dts
@@ -238,13 +238,13 @@
 	"", "", "", "";
 
 	uart0_pins_active: uart0_pins@0 {
-		pins = "", "";
+		pins = "PB9", "PB10";
 		function = "uart0";
 		drive-strength = <10>;
 	};
 
 	uart0_pins_sleep: uart0_pins@1 {
-		pins = "", "";
+		pins = "PB9", "PB10";
 		function = "gpio_in";
 		drive-strength = <10>;
 	};


### PR DESCRIPTION
The `uart0_pins_active` / `uart0_pins_sleep` nodes on the Cubie A7S ship with empty pin lists:

```
pins = "", "";
```

so the uart0 pinmux is never applied. Populate both with the A7S uart0 pins `PB9`/`PB10` so the port is muxed correctly.

Scope: uart0 only — `uart1_pins_*` (also empty) left untouched.

Tested on Cubie A7S (A733).