### PR TITLE
arm64: dts: cubie-a7s: set GPU clk_rate to 600 MHz

### DIFF
--- a/configs/cubie_a7s/linux-6.6/board.dts
+++ b/configs/cubie_a7s/linux-6.6/board.dts
@@ -1954,6 +1954,7 @@
 
 &gpu  {
 	gpu-supply = <&reg_dcdc4>;
+	clk_rate = <600000000>;
 };
 
 &sid {


### PR DESCRIPTION
The Cubie A7S `&gpu` node had no `clk_rate`, leaving the GPU clock at its default. Set `clk_rate = <600000000>` (600 MHz).

Tested on Cubie A7S (A733).