### PR TITLE
arm64: dts: cubie-a7s: power PCIe/NVMe HAT via fixed-regulator on PD20

### DIFF
--- a/configs/cubie_a7s/linux-6.6/board.dts
+++ b/configs/cubie_a7s/linux-6.6/board.dts
@@ -70,6 +70,19 @@
 		regulator-boot-on;
 	};
 
+	reg_pcie_pwr: pcie-pwr {
+		/* FPC PCIe/NVMe HAT power-enable: PD20 = PCIE_PWR_EN (J3 pin14). */
+		compatible = "regulator-fixed";
+		regulator-name = "pcie-pwr";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-enable-ramp-delay = <1000>;
+		gpio = <&pio PD 20 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
 	arisc_config: arisc_config {
 		s_uart_config{
 			pins = "PL2", "PL3";
@@ -1082,7 +1095,6 @@
 &pcie_rc {
 	pcie1v8-supply = <&reg_dc1sw1>;
 	pcie3v3-supply = <&reg_bldo2>;
-	power-gpios =  <&pio PD 20 GPIO_ACTIVE_HIGH>;
 	reset-gpios = <&pio PD 22 GPIO_ACTIVE_HIGH>;
 	wake-gpios = <&pio PD 21 GPIO_ACTIVE_HIGH>;
 	status = "okay";


### PR DESCRIPTION
Reworks the Cubie A7S PCIe/NVMe HAT power-enable to the device-tree approach requested in the review of allwinner-bsp#16:

> "The device tree should define a `fixed-regulator` to consume the pin, not changing the driver."

**PD20 = `PCIE_PWR_EN`** (J3 FPC pin14, active-high, gpio116) enables power to the PCIe/NVMe HAT. This models it as a `regulator-fixed` owned by the DT and enabled at boot via `regulator-always-on` + `regulator-boot-on` — the regulator core drives PD20 high at registration, so no PCIe driver change is needed. It mirrors the existing `wifi_power_en` / `wifi_chip_en` / `eeprom_wp` fixed-regulators in this board.dts, and gives clean power-before-PERST ordering.

`power-gpios` is removed from `&pcie_rc` so PD20 is owned solely by the regulator (no double-claim).

**Supersedes allwinner-bsp#16** (the driver change is no longer needed).

Build-tested: `board.dts` cpp+dtc-compiles clean against the linux-6.6 tree (no new warnings/errors); decompiled dtb confirms the regulator with `gpio = <&pio PD 20 GPIO_ACTIVE_HIGH>`.